### PR TITLE
Vorschlag Änderung WO

### DIFF
--- a/electoral_code.md
+++ b/electoral_code.md
@@ -2,7 +2,7 @@
 
 *This translation is for information purposes only and is not legally binding.*
 
-This electoral code came into effect by resolution of all members at a general meeting on May 3, 2018.
+This electoral code came into effect by resolution of the Student Representative Group on XXX XX, XXXX.
 
 
 
@@ -47,7 +47,7 @@ Every member of the student body has the right to vote and to stand as a candida
 
 (4) The members of the election committee cannot run for election.
 
-(5) The election committee may call on additional people to assist in an election and vote counting. These people do not need to belong to the student body.
+(5) The election committee may call on additional people to assist in an election and vote counting. These people do not need to belong to the student body but must not have run for election.
 
 (6) The Student Representative Group must provide the election committee with all materials necessary to prepare and conduct the election.
 
@@ -56,7 +56,7 @@ Every member of the student body has the right to vote and to stand as a candida
 
 (1) The election committee shall announce the election to the Student Representative Group no later than three weeks before the election is to take place. The notice of election is to be made to the student body by email.
 
-(2) The notice of election provides information about the time, place and other modalities of the election. It should contain the information listed in § 11 of the Framework Regulations for Elections of the Student Body of the University of Potsdam, dated May 8, 2012.
+(2) The notice of election provides information about the time, place and other modalities of the election. It should contain the information listed in § 12 of the Framework Regulations for Elections of the Student Body of the University of Potsdam, dated February 6, 2018.
 
 
 ## § 8 Electoral Proposals
@@ -96,14 +96,14 @@ Every member of the student body has the right to vote and to stand as a candida
 
 ## § 11 Announcement of Election Result
 
-(1) The election committee shall announce the results of the election to the student body via email, at the latest on the first day of classes after acceptance. The election committee will also notify all elected members.
+(1) The election committee shall announce the results of the election to the student body via email, at the latest on the first day of classes after acceptance.
 
 (2) The election committee shall invite those elected into the Student Representative Group to a constituent meeting one week, at the latest, after the results of the election have been made public.
 
 
 ## § 12 Appeals Period
 
-(1) The election can be appealed within one week after the publication of the results. An appeal stating the reason(s) for the appeal must be made to the election committee. Only the reasons listed in § 20 (2) of the Framework Regulations for Elections of the Student Body of the University of Potsdam, dated May 8, 2012 will be considered.
+(1) The election can be appealed within one week after the publication of the results. An appeal stating the reason(s) for the appeal must be made to the election committee. Only the reasons listed in § 21 (2) of the Framework Regulations for Elections of the Student Body of the University of Potsdam, dated February 6, 2018 will be considered.
 
 (2) The admissibility and consequences of the appeal is decided by the election committee.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -1,6 +1,6 @@
 # Wahlordnung der Fachschaft Digital Engineering an der Universität Potsdam
 
-Diese Wahlordnung ist am 03.05.2018 durch Beschluss der Vollversammlung in Kraft getreten.
+Diese Wahlordnung ist am XX.XX.XXXX durch Beschluss des Fachschaftsrates in Kraft getreten.
 
 
 
@@ -45,7 +45,7 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (4) Mitglieder des Wahlausschusses können nicht für die Wahlen kandidieren.
 
-(5) Der Wahlausschuss kann weitere Personen zur Unterstützung während der Wahlhandlung und Auszählung heranziehen. Diese müssen nicht der Fachschaft angehören.
+(5) Der Wahlausschuss kann weitere Personen zur Unterstützung während der Wahlhandlung und Auszählung heranziehen. Diese müssen nicht der Fachschaft angehören, dürfen aber ebenfalls nicht selbst kandidiert haben.
 
 (6) Der Fachschaftsrat muss dem Wahlausschuss alle zur Vorbereitung und Durchführung der Wahlen notwendigen Materialien zur Verfügung stellen.
 
@@ -54,7 +54,7 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (1) Der Wahlausschuss schreibt die Wahlen zum Fachschaftsrat spätestens drei Wochen vor der Wahl aus. Die Wahlbekanntmachung ist durch E-Mail an die Fachschaft zu veröffentlichen.
 
-(2) Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in § 11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Hinweise beinhalten.
+(2) Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in § 12 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 6. Februar 2018 aufgeführten Hinweise beinhalten.
 
 
 ## § 8 Wahlvorschläge
@@ -94,14 +94,14 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 ## § 11 Bekanntgabe des Wahlergebnisses
 
-(1) Der Wahlausschuss gibt die Ergebnisse der Wahl spätestens einen Vorlesungstag nach der Annahme aller Mitglieder per E-Mail an die Fachschaft bekannt. Er benachrichtigt ferner die gewählten Mitglieder des jeweiligen Gremiums.
+(1) Der Wahlausschuss gibt die Ergebnisse der Wahl spätestens einen Vorlesungstag nach der Annahme aller Mitglieder per E-Mail an die Fachschaft bekannt.
 
 (2) Der Wahlausschuss lädt die in den Fachschaftsrat gewählten Mitglieder zu einem spätestens eine Woche nach der Bekanntgabe der Wahlergebnisse liegenden Termin zur konstituierenden Sitzung ein.
 
 
 ## § 12 Anfechtungsfrist
 
-(1) Die Wahl kann innerhalb einer Woche nach Veröffentlichung des Wahlergebnisses angefochten werden. Eine Anfechtung erfolgt schriftlich unter Angabe der Gründe beim Wahlausschuss. Es kommen nur die in § 20 (2) der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Gründe in Betracht.
+(1) Die Wahl kann innerhalb einer Woche nach Veröffentlichung des Wahlergebnisses angefochten werden. Eine Anfechtung erfolgt schriftlich unter Angabe der Gründe beim Wahlausschuss. Es kommen nur die in § 21 (2) der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 6. Februar 2018 aufgeführten Gründe in Betracht.
 
 (2) Über Zulässigkeit und Folgen der Anfechtung entscheidet der Wahlausschuss.
 


### PR DESCRIPTION
Erläuterungen / *Explanations*
- § 6 (5)
    - Regelung analog zu § 11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam
    - *Change analogous to § 11 in the Framework Regulations for Elections of the Student Body of the University of Potsdam*
- § 7 (2), § 12 (1)
    - Aktualisierung der Referenz auf die aktuelle Rahmenwahlordnung 
    - *Updating the reference to the current Framework Regulations*
- § 11 (1)
    - Entfernen einer redundanten Regelung. Es muss ohnehin die gesamte Fachschaft informiert werden.
    - *Removal of an obsolete phrase. The complete student body must be informed anyway.*
