### PR TITLE
[nicht inhaltlich] Grammatik korrigiert

### DIFF
--- a/geschaeftsordnung.md
+++ b/geschaeftsordnung.md
@@ -70,7 +70,7 @@ Bei der Anwesenheit von Mitgliedern des Fachschaftsrates während seiner Sitzung
 
 (2) Die Sitzungsleitung ist verantwortlich für die Festlegung der Protokollführung, Verwaltung der Tagesordnung und einen geordneten Ablauf der Sitzung.
 
-(3) Die Sitzungsleitung wird in der Regel durch den Vorsitz wahrgenommen. Es steht ihnen frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen. Diese Entscheidung erhält per Mitteilung an den gesamten Fachschaftsrat Gültigkeit.
+(3) Die Sitzungsleitung wird in der Regel durch den Vorsitz wahrgenommen. Es steht ihm frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen. Diese Entscheidung erhält per Mitteilung an den gesamten Fachschaftsrat Gültigkeit.
 
 
 ## § 8 Beschlüsse


### PR DESCRIPTION
Das "ihnen" (Plural) bezieht sich grammatikalisch nicht auf die Sitzungsleitung (Singular) oder den Vorsitz (Singular) – vermutlich auf dessen Mitglieder, aber dafür ist es komisch formuliert. Ich vermute mal, es geht hier um den Vorsitz, und habe es dementsprechend angepasst.