### PR TITLE
Satzungsänderungsquote

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -84,4 +84,7 @@ Zu den Aufgaben des Fachschaftsrates gehören insbesondere:
 
 ## § 7 Satzungsänderungen
 
-Die Änderung der Satzung kann nur erfolgen, wenn zwei Drittel der bei einer Vollversammlung stimmberechtigten Anwesenden dem Antrag zustimmen.
+Die Änderung der Satzung kann nur erfolgen, wenn
+
+* auf einer Vollversammlung wenigstens 20% der Mitglider der Fachschaft anwesend sind und
+* wenigstens zwei Drittel der bei dieser Vollversammlung stimmberechtigten Anwesenden dem Antrag zustimmen.

--- a/satzung.md
+++ b/satzung.md
@@ -86,5 +86,5 @@ Zu den Aufgaben des Fachschaftsrates gehören insbesondere:
 
 Die Änderung der Satzung kann nur erfolgen, wenn
 
-* auf einer Vollversammlung wenigstens 20% der Mitglider der Fachschaft anwesend sind und
+* auf einer Vollversammlung wenigstens 20% der Mitglieder der Fachschaft anwesend sind und
 * wenigstens zwei Drittel der bei dieser Vollversammlung stimmberechtigten Anwesenden dem Antrag zustimmen.

--- a/satzung.md
+++ b/satzung.md
@@ -1,6 +1,6 @@
 # Satzung der Fachschaft Digital Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Satzung ist am 14.11.2019 durch Beschluss der Vollversammlung in Kraft getreten.
+Diese Satzung ist am xx.xx.xxxx durch Beschluss der Vollversammlung in Kraft getreten.
 
 
 

--- a/statutes.md
+++ b/statutes.md
@@ -2,7 +2,7 @@
 
 *This translation is for information purposes only and is not legally binding.*
 
-These statutes came into effect by resolution of all members at a general meeting on Nov. 14, 2019.
+These statutes came into effect by resolution of all members at a general meeting on xxx. xx, xxxx.
 
 
 
@@ -87,4 +87,7 @@ Among the particular tasks of the Student Representative Group are:
 
 ## § 7 Amendments
 
-Changes to the statutes can only be made if two-thirds of those present at a general meeting agree to the proposal.
+Changes to the statutes can only be made if
+
+* at least 20% of the student body's members are present at a general meeting and
+* two-thirds of those present at the general meeting agree to the proposal.


### PR DESCRIPTION
Aktuell kann auch eine kleine Vollversammlung die Satzung ändern. Um Missbrauch zu vermeiden, könnten wir eine Quote einführen. Zunächst schlage ich dafür `20%` Anwesenheit vor. Von den etwa 600 Mitgliedern der Fachschaft waren in der Vergangenheit etwa 250 zur ordentlichen Vollversammlung anwesend, sodass sich mit etwas Puffer dieser Wert als erster Vorschlag ergeben hat.