### PR TITLE
E-Mail Wahl streichen

### DIFF
--- a/electoral_code.md
+++ b/electoral_code.md
@@ -74,9 +74,9 @@ Every member of the student body has the right to vote and to stand as a candida
 
 (2) Voters are not bound to the electoral proposals.
 
-(3) Voters will be given the opportunity to vote by email from the time candidates are announced. The email procedure must reflect a postal vote—insofar as the cast vote cannot be matched to the voter. To carry out this procedure, the vote is cast in the form of an email attachment, which can be evaluated separately from the email itself. The casting of a vote by email must be done using the HPI account.
+(3) Voters will be given the opportunity to vote by postal ballot or in person.
 
-(4) If a person has voted both by email and by ballot, the vote cast by email will be forfeited.
+(4) If a person has voted both by postal ballot and in person, the vote cast by postal ballot will be forfeited.
 
 (5) If there are several people with the same name, the name used in the HPI domain with a number added to it will be used for voting. The election committee will explain this at the opening of the election.
 

--- a/electoral_code.md
+++ b/electoral_code.md
@@ -74,7 +74,7 @@ Every member of the student body has the right to vote and to stand as a candida
 
 (2) Voters are not bound to the electoral proposals.
 
-(3) Voters will be given the opportunity to vote by postal ballot or in person.
+(3) Voters are given the opportunity to vote by postal ballot or in person.
 
 (4) If a person has voted both by postal ballot and in person, the vote cast by postal ballot will be forfeited.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -72,9 +72,7 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (2) Wählende sind nicht an die Wahlvorschläge gebunden.
 
-(3) Wahlberechtigten wird ab der Bekanntgabe der Wahlvorschläge die Möglichkeit gegeben, ihre Stimme per E-Mail abzugeben. Dieses Verfahren muss einer Briefwahl insofern entsprechen, als abgegebene Stimmen der wählenden Person nicht zugeordnet werden dürfen. Dafür ist die Stimmabgabe in einem getrennt von der E-Mail auszuwertenden Anhang zu tätigen. Die Abgabe der Stimmen per E-Mail muss vom HPI-Konto erfolgen.
-
-(4) Wenn eine Person sowohl per E-Mail als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der E-Mail.
+(3) Wahlberechtigten wird die Möglichkeit gegeben, ihre Stimme per Urnen- oder Briefwahl abzugeben.
 
 (5) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -74,7 +74,9 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (3) Wahlberechtigten wird die Möglichkeit gegeben, ihre Stimme per Urnen- oder Briefwahl abzugeben.
 
-(4) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
+(4) Wenn eine Person sowohl per Briefwahl als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der Briefwahl.
+
+(5) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
 
 
 ## § 10 Ergebnisfeststellung

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -74,7 +74,7 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (3) Wahlberechtigten wird die Möglichkeit gegeben, ihre Stimme per Urnen- oder Briefwahl abzugeben.
 
-(4) Wenn eine Person sowohl per Briefwahl als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der Briefwahl.
+(4) Wenn eine Person sowohl per Briefwahl als auch per Urnenwahl abgestimmt hat, verfällt die Stimmabgabe aus der Briefwahl.
 
 (5) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -74,7 +74,7 @@ Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
 
 (3) Wahlberechtigten wird die Möglichkeit gegeben, ihre Stimme per Urnen- oder Briefwahl abzugeben.
 
-(5) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
+(4) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist zur Eröffnung der Wahl darauf hin.
 
 
 ## § 10 Ergebnisfeststellung


### PR DESCRIPTION
E-Mail Wahlen rausgestrichen, dafür nochmal explizit Urnen- und Briefwahl als Möglichekeiten genannt
Co-authored-by: @ArminWel