### PR TITLE
Simplification of online attendence

### DIFF
--- a/geschaeftsordnung-fachschaftsrat.md
+++ b/geschaeftsordnung-fachschaftsrat.md
@@ -1,6 +1,6 @@
 # Geschäftsordnung des Fachschaftsrates Digital Engineering
 
-Diese Geschäftsordnung wurde am 29.03.2023 vom Fachschaftsrat beschlossen.
+Diese Geschäftsordnung wurde am 21.12.2023 vom Fachschaftsrat beschlossen.
 
 
 ## § 1 Geltungsbereich und Definitionen
@@ -30,8 +30,8 @@ Diese Geschäftsordnung wurde am 29.03.2023 vom Fachschaftsrat beschlossen.
 (2) Der Fachschaftsrat wählt auf der konstituierenden Sitzung aus seiner Mitte
 
 1. eine vorsitzende Person und ggf. deren Stellvertretung,
-2. eine für die Finanzverwaltung beauftragte Person und ggf. deren Stellvertretung,
-3. eine für die Vernetzung mit den anderen Organen der Studierendenschaft im Sinne der Satzung der Studierendenschaft der Universität Potsdam beauftragte Person.
+2. ein für die Finanzen verantwortliches Mitglied und ggf. dessen Stellvertretung,
+3. ein Mitglied, dem die Vertretung in der Versammlung der Fachschaften nach § 9 Satzung der Studierendenschaft der Universität Potsdam (SdS) vorrangig obliegt.
 
 (3) Die Wahlen auf der konstituierenden Sitzung finden gemäß § 2 statt und werden vom Wahlausschuss geleitet. Nach der Wahl übernimmt der Vorsitz die Sitzungsleitung.
 
@@ -40,9 +40,9 @@ Diese Geschäftsordnung wurde am 29.03.2023 vom Fachschaftsrat beschlossen.
 
 (1) Der Vorsitz des Fachschaftsrates ist verantwortlich für die Sitzungsleitung gemäß § 7.
 
-(2) Die für die Finanzverwaltung beauftragten Personen verwalten die Finanzen der Fachschaft gemäß den Beschlüssen des Fachschaftsrates. Sie sind zu einzeln Verfügungsberechtigten zu erklären. Sie sollten den Finanz-Workshop des Allgemeinen Studierendenausschusses (AStA) der Universität Potsdam besuchen.
+(2) Die für die Finanzen verantwortlichen Mitglieder verwalten die Finanzen der Fachschaft gemäß den Beschlüssen des Fachschaftsrates. Sie sind zu einzeln Verfügungsberechtigten zu erklären. Sie sollten den Finanz-Workshop des Allgemeinen Studierendenausschusses (AStA) der Universität Potsdam besuchen.
 
-(3) Zu Beginn jeder Sitzung ist von der Sitzungsleitung eine Person mit der Protokollführung zu beauftragen, die alle Beschlüsse der Sitzung und diskutierte Punkte in einem Protokoll festhält. Die Protokollführung muss persönlich anwesend sein. Weiteres regelt § 10.
+(3) Zu Beginn jeder Sitzung ist von der Sitzungsleitung eine Person mit der Protokollführung zu beauftragen, die alle Beschlüsse der Sitzung und diskutierte Punkte in einem Protokoll festhält. Weiteres regelt § 10.
 
 (4) Die in § 3 (2) festgelegten Ämter können jeweils durch ein konstruktives Misstrauensvotum des Fachschaftsrates oder nach dem Rücktritt einer Person von diesem Amt neu vergeben werden. Wird das Amt einer Stellvertretung frei, findet eine Neuwahl nur auf Beschluss des Fachschaftsrates statt.
 
@@ -51,40 +51,39 @@ Diese Geschäftsordnung wurde am 29.03.2023 vom Fachschaftsrat beschlossen.
 
 ## § 5 Anwesenheit
 
-Bei der Anwesenheit von Mitgliedern des Fachschaftsrates während seiner Sitzungen wird unterschieden:
-
-1. Persönliche Anwesenheit: Alle Mitglieder des Fachschaftsrates, die sich während der Sitzung am Ort der Sitzung befinden, gelten als persönlich anwesend.
-2. Anwesenheit: Alle Mitglieder des Fachschaftsrates, die während der Sitzung persönlich anwesend sind oder per Telefon oder anderweitiger Einrichtung zur Kommunikation, insbesondere Internet- oder Videotelefonie, teilnehmen, gelten als anwesend.
+Alle Mitglieder des Fachschaftsrates, die sich während der Sitzung am Ort der Sitzung befinden oder per Telefon oder anderweitiger Einrichtung zur Kommunikation, insbesondere Internet- oder Videotelefonie, teilnehmen, gelten als anwesend.
 
 
 ## § 6 Sitzungen
 
 (1) Während der Vorlesungszeit soll gemäß Satzung der Fachschaft Digital Engineering jede Woche eine Sitzung stattfinden. In der vorlesungsfreien Zeit und in den akademischen Weihnachtsferien soll mindestens alle drei Wochen eine Sitzung stattfinden.
 
-(2) Der Vorsitz lädt zu den Sitzungen per E-Mail über einen öffentlichen Verteiler alle interessierten Mitglieder der Fachschaft ein.
+(2) Der Vorsitz lädt zu den Sitzungen per E-Mail über einen öffentlichen Verteiler alle interessierten Mitglieder der Fachschaft ein. Die Einladung soll am Vortag erfolgen.
+
+(3) Die Sitzung soll nach Möglichkeit in den Räumen der
+Hasso-Plattner-Institut gGmbh stattfinden.
 
 
 ## § 7 Sitzungsleitung
 
-(1) Während jeder Sitzung muss ein persönlich anwesendes Mitglied die Sitzungsleitung innehaben.
+(1) Während jeder Sitzung muss ein anwesendes Mitglied die Sitzungsleitung innehaben.
 
 (2) Die Sitzungsleitung ist verantwortlich für die Festlegung der Protokollführung, Verwaltung der Tagesordnung und einen geordneten Ablauf der Sitzung.
 
-(3) Die Sitzungsleitung wird in der Regel durch den Vorsitz wahrgenommen. Es steht ihm frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen. Diese Entscheidung erhält per Mitteilung an den gesamten Fachschaftsrat Gültigkeit.
+(3) Die Sitzungsleitung wird in der Regel durch den Vorsitz wahrgenommen. Es steht ihm frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen.
 
 
 ## § 8 Beschlüsse
 
-(1) Der Fachschaftsrat ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder anwesend ist, wobei mindestens zwei Mitglieder persönlich anwesend sein müssen.
+(1) Der Fachschaftsrat ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder anwesend ist.
 
-(2) Wenn eine persönliche Zusammenkunft aufgrund äußerer Faktoren nicht möglich oder nicht ratsam ist, kann der Vorsitz einstimmig festlegen, eine Sitzung in Form einer Telefonkonferenz ohne festen Ort stattfinden zu lassen. Abweichend von § 5 gelten in diesem Fall alle anwesenden Mitglieder als persönlich anwesend. Eine Sitzung dieser Form ist der Fachschaft mindestens 24 Stunden im Voraus mit einer Begründung für den Ausnahmefall anzukündigen. Auf den besonderen Sitzungsmodus ist mit Wiederholung der Begründung im Protokoll hinzuweisen.
+(2) Beschlüsse werden in einer offenen Abstimmung aller anwesenden Mitglieder gefasst. Ein Beschluss gilt als angenommen, wenn er mehr Ja- als Nein-Stimmen erhält. Bei Stimmengleichheit zwischen Ja- und Nein-Stimmen gilt ein Beschluss als nicht gefasst.
 
-(3) Beschlüsse werden in einer offenen Abstimmung aller anwesenden Mitglieder gefasst. Ein Beschluss gilt als angenommen, wenn er mehr Ja- als Nein-Stimmen erhält. Bei Stimmengleichheit zwischen Ja- und Nein-Stimmen gilt ein Beschluss als nicht gefasst.
-
-(4) Abweichend von (3) gilt ein Beschluss als nicht gefasst, wenn mehr Enthaltungen als Ja- und Nein-Stimmen zusammengezählt abgegeben wurden.
+(4) Abweichend von (2) gilt ein Beschluss als nicht gefasst, wenn mehr Enthaltungen als Ja- und Nein-Stimmen zusammengezählt abgegeben wurden.
 
 (5) Die Beschlüsse des Fachschaftsrates werden in Protokollen festgehalten.
 
+(6) Die Anwendung von § 5 (4) SdS gilt als missbräuchlich.
 
 ## § 9 Umlaufbeschlüsse
 
@@ -105,11 +104,12 @@ Bei der Anwesenheit von Mitgliedern des Fachschaftsrates während seiner Sitzung
 
 (1) Das Protokoll jeder Sitzung muss mindestens die folgenden Punkte enthalten:
 
-1. Datum
-2. Anwesende Mitglieder
-3. Sitzungsleitung
-4. Protokollführung
-5. Beschreibung der Anträge und Beschlüsse mit genauen Abstimmungsergebnissen
+1. Tag, Zeit und Ort der Sitzung
+2. Namentliche Anwesenheitsliste
+3. Hinweis zur Beschlussfähigkeit inkl. Anzahl der anwesenden Mitglieder
+4. Sitzungsleitung
+5. Protokollführung
+6. Beschreibung der Anträge und Beschlüsse inkl. Stimmverteilungen
 
 (2) Die Sitzungsprotokolle werden allen Mitgliedern des Fachschaftsrates spätestens am Arbeitstag nach der Sitzung zugänglich gemacht.
 

--- a/geschaeftsordnung-fachschaftsrat.md
+++ b/geschaeftsordnung-fachschaftsrat.md
@@ -79,11 +79,11 @@ Hasso-Plattner-Institut gGmbh stattfinden.
 
 (2) Beschlüsse werden in einer offenen Abstimmung aller anwesenden Mitglieder gefasst. Ein Beschluss gilt als angenommen, wenn er mehr Ja- als Nein-Stimmen erhält. Bei Stimmengleichheit zwischen Ja- und Nein-Stimmen gilt ein Beschluss als nicht gefasst.
 
-(4) Abweichend von (2) gilt ein Beschluss als nicht gefasst, wenn mehr Enthaltungen als Ja- und Nein-Stimmen zusammengezählt abgegeben wurden.
+(3) Abweichend von (2) gilt ein Beschluss als nicht gefasst, wenn mehr Enthaltungen als Ja- und Nein-Stimmen zusammengezählt abgegeben wurden.
 
-(5) Die Beschlüsse des Fachschaftsrates werden in Protokollen festgehalten.
+(4) Die Beschlüsse des Fachschaftsrates werden in Protokollen festgehalten.
 
-(6) Die Anwendung von § 5 (4) SdS gilt als missbräuchlich.
+(5) Die Anwendung von § 5 (4) SdS gilt als missbräuchlich.
 
 ## § 9 Umlaufbeschlüsse
 

--- a/rules_of_procedure-student_representative_group.md
+++ b/rules_of_procedure-student_representative_group.md
@@ -63,7 +63,7 @@ A distinction is made regarding the presence of members of the Student Represent
 
 (1) During the instructional period of the semester a meeting shall take place once every week as stated in the Statutes of the Digital Engineering Student Body. In the time between instructional periods and within the christmas break a meeting shall take place at least once every three weeks.
 
-(2) The chairpersons shall invite all interested members of the student body to the meetings via a publicly available email distribution list.
+(2) The chairpersons shall invite all interested members of the student body to the meetings via a publicly available email distribution list. The invitation should be sent the day before the meeting.
 
 (3) If possible, the meeting should take place on the premises of the
 Hasso Plattner Institute gGmbh.

--- a/rules_of_procedure-student_representative_group.md
+++ b/rules_of_procedure-student_representative_group.md
@@ -2,7 +2,7 @@
 
 *This translation is for information purposes only and is not legally binding.*
 
-These Rules of Procedure were established by the Student Representative Group on Mar. 29, 2023.
+These Rules of Procedure were established by the Student Representative Group on Dec. 21, 2023.
 
 
 
@@ -32,32 +32,31 @@ These Rules of Procedure were established by the Student Representative Group on
 
 (2) At the constituent meeting, the Student Representative Group elects from among its members
 
-1.	a chairperson and, when appropriate, a deputy chairperson
-2.	a financial officer and, when appropriate, a deputy financial officer
-3.	a representative for networking with other student body committees, in the sense of the Statutes of the Student Body of the University of Potsdam
+1.	a chairperson and, when appropriate, their deputy
+2.	a member responsible for finances and, when appropriate, their deputy 
+3.	a member who is the main representative in the Assembly of Student Representatives in accordance with § 9 Statutes of the Student Body of the University of Potsdam (SdS)
 
 (3) Elections are carried out at the constituent meeting in accordance with § 2 and are led by the election committee. After the election has concluded, the chairperson takes over the meeting.
 
 
 ## § 4 Allocation of Responsibilities
 
-(1) The chairpersons of the Student Representative Group are responsible for chairing the meetings in accordance with § 6.
+(1) The chairpersons of the Student Representative Group are responsible for chairing the meetings in accordance with § 7.
 
-(2) The financial officers handle the finances of the student body based on the resolutions of the Student Representative Group. They are declared as separately authorized officers. The financial officers are expected to attend the finance workshop of the General Student Committee (AStA) at the University of Potsdam.
+(2) The members responsible for finances handle the finances of the student body based on the resolutions of the Student Representative Group. They are declared as separately authorized officers. The financial officers are expected to attend the finance workshop of the General Student Committee (AStA) at the University of Potsdam.
 
-(3) At the beginning of each meeting, the chairing person shall appoint a minute-taking person, who records the minutes of the meeting including all decisions made and points discussed. The minute-taking person must be physically present at the meeting. Further details are outlined in § 8.
+(3) At the beginning of each meeting, the chairing person shall appoint a minute-taking person, who records the minutes of the meeting including all decisions made and points discussed. Further details are outlined in § 8.
 
 (4) The offices defined in § 3 (2) can each be newly reassigned by the Student Representative Group in case of a constructive vote of no confidence or following the resignation of an office holder, respectively. If the office of a deputy becomes vacant, a new election will only take place by a resolution of the Student Representative Group.
 
-(5) All other areas of competency shall be resolved internally.
+(5) All other areas of competency can be determined internally by resolution.
 
 
 ## § 5 Attendance
 
-A distinction is made regarding the presence of members of the Student Representative Group during its meetings:
 
-1.	Physical presence: All members of the Student Representative Group who are at the place of the meeting for the meeting are considered physically present.
-2.	Present: All members of the Student Representative Group who are physically present during the meeting or who take part via telephone or by other means of communication, in particular via internet or video telephony, are deemed to be present.
+All members of the Student Representative Council who are present at the location of the meeting during the meeting or who participate by telephone or other means of communication, in particular internet or videotelephony, are deemed to be present.
+A distinction is made regarding the presence of members of the Student Representative Group during its meetings:
 
 
 ## § 6 Meetings
@@ -66,29 +65,31 @@ A distinction is made regarding the presence of members of the Student Represent
 
 (2) The chairpersons shall invite all interested members of the student body to the meetings via a publicly available email distribution list.
 
+(3) If possible, the meeting should take place on the premises of the
+Hasso Plattner Institute gGmbh.
+
 
 
 ## § 7 Chairing the Meeting
 
-(1) During every meeting a physically present member is required to chair the meeting.
+(1) During every meeting a present member is required to chair the meeting.
 
 (2) The chairing person is responsible for determining the minute-taking duties, managing the agenda and an orderly course of the meeting.
 
-(3) Generally, the meetings shall be chaired by the chairpersons. They are however free, by unanimous consent, to transfer the task of chairing the meeting in question to another member. This decision is considered valid upon communication to the entire Student Representative Group.
+(3) Generally, the meetings shall be chaired by the chairpersons. They are however free, by unanimous consent, to transfer the task of chairing the meeting in question to another member.
 
 
 ## § 8 Resolutions
 
-(1) The Student Representative Group is authorized to pass a resolution if at least half of its members are present, with at least two members being physically present.
+(1) The Student Representative Group is authorized to pass a resolution if at least half of its members are present.
 
-(2) If a face-to-face meeting is not possible or not advisable due to external factors, the chairpersons may unanimously decide to hold a meeting in the form of a telephone conference without a fixed venue. Contrary to § 5, in this case all members present shall be deemed to be physically present. The student body must be notified of a meeting of this form at least 24 hours in advance, with a justification for the exceptional case. The special meeting mode is to be pointed out in the minutes with a repetition of the justification.
+(2) Resolutions are passed in an open vote by all members present. A resolution is considered accepted if it receives more “yes” than “no” votes. In case of a tie between “yes” and “no” votes, a resolution is not considered as adopted.
 
-(3) Resolutions are passed in an open vote by all members present. A resolution is considered accepted if it receives more “yes” than “no” votes. In case of a tie between “yes” and “no” votes, a resolution is not considered as adopted.
+(3) By way of derogation from (2), a resolution is not considered as adopted if more abstentions have been cast than the total “yes” and “no” votes together.
 
-(4) By way of derogation from (3), a resolution is not considered as adopted if more abstentions have been cast than the total “yes” and “no” votes together.
+(4) The resolutions of the Student Representative Group are recorded in the minutes.
 
-(5) The resolutions of the Student Representative Group are recorded in the minutes.
-
+(5) The application of § 5 (4) SdS is abusive.
 
 ## § 9 Circulation Resolutions
 
@@ -109,11 +110,12 @@ A distinction is made regarding the presence of members of the Student Represent
 
 (1) The minutes of each meeting must contain at least the following items:
 
-1.	Date
-2.	Members in attendance
-3.	Person chairing the meeting
-4.	Person taking the minutes
-5.	Description of motions and resolutions, with the exact results of voting
+1.	Date, time and location of the meeting
+2.  Attendance list by name
+3.  Indication of quorum incl. number of members present
+4.	Person chairing the meeting
+5.	Person taking the minutes
+6.	Description of motions and resolutions, incl. the distribution of votes
 
 (2) The minutes of the meeting will be made available to all members of the Student Representative Group no later than the working day after the meeting.
 


### PR DESCRIPTION
Nach Diskussion wurde sich auf folgende, hier umgesetzte Änderungen geeinigt:

1. Es wird nicht mehr zwischen Präsenz- und Onlineteilnahme unterschieden
2. Sitzungen sollen, wenn möglich, am HPI erfolgen. Regelungen zu online Sitzungen entfallen.
3. Einladungen zu Sitzungen sollen am Vortag erfolgen
4. Übergabe der Sitzungsleitung muss nicht mehr dem gesamten FSR mitgeteilt werden
5. Die Anwendung von § 5 (4) SdS (Beschluss ohne Quorum) ist missbräuchlich
6. In Protokollen muss nun gem. § 6 (2) SdS Zeit und Ort der Sitzung angeben werden. 
7. Klarstellung: Die Abstimmungsergebnisse soll als Stimmverteilung, nicht pro Person angeben werden.
8. Anpassung der Ämter, sodass die Namen mit § 8 (3) SdS übereinstimmen.
9. Übersetzungsfehler im Englischen korrigiert.