### PR TITLE
Antrag an den FSR: FSR-Wahlfrist auf 6 Wochen nach VL-Beginn verlängern // Motion in the FSR: Extend FSR election deadline to six weeks after the start of the lecture period

### DIFF
--- a/electoral_code.md
+++ b/electoral_code.md
@@ -20,7 +20,7 @@ Based on the Statutes of the Digital Engineering Student Body, eight members are
 
 (1) The Student Representative Group is elected for a one-year term. The members remain in office until the succeeding members take office.
 
-(2) Elections generally take place at the beginning of the start of classes in each summer semester, and, at the latest, one month after beginning of the start of classes. In the event of a new election before a complete legislative period has ended, this date will be adjusted accordingly.
+(2) Elections generally take place at the beginning of the start of classes in each summer semester, and, at the latest, in the sixth week of the lecture period. In the event of a new election before a complete legislative period has ended, this date will be adjusted accordingly.
 
 (3) The election period is understood as the time between the convening of the election committee and the expiration of the appeals period.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -18,7 +18,7 @@ In den Fachschaftsrat werden gemäß Satzung der Fachschaft Digital Engineering 
 
 (1) Der Fachschaftsrat wird für ein Jahr gewählt und bleibt darüber hinaus bis zum Amtsantritt der neu gewählten Mitglieder kommissarisch im Amt.
 
-(2) Die Wahlen finden gewöhnlich zu Beginn der Vorlesungszeit jedes Sommersemesters statt, spätestens aber einen Monat nach Vorlesungsbeginn. Im Falle einer Neuwahl vor Ablauf einer vollständigen Legislaturperiode ist dieser Zeitpunkt entsprechend anzupassen.
+(2) Die Wahlen finden gewöhnlich zu Beginn der Vorlesungszeit jedes Sommersemesters statt, spätestens aber in der sechsten Woche der Vorlesungszeit. Im Falle einer Neuwahl vor Ablauf einer vollständigen Legislaturperiode ist dieser Zeitpunkt entsprechend anzupassen.
 
 (3) Als Zeitraum der Wahlen ist die Zeit zwischen Einberufung des Wahlausschusses und Ablauf der Anfechtungsfrist zu verstehen.
 


### PR DESCRIPTION
[English version below]

# Antrag
Der Fachschaftsrat möge die Wahlordnung der Fachschaft Digital Engineering wie folgt ändern.

In § 3 (2) Satz 1 wird die Wendung "spätestens aber einen Monat nach Vorlesungsbeginn" durch die Wendung "spätestens aber in der sechsten Woche der Vorlesungszeit" ersetzt.

# Begründung

Traditionell finden die Wahlen der Fachschaft, die Vollversammlung und das Frühlingsfest gemeinsam statt. Dadurch haben Kandidierende die Möglichkeit, sich auf der Vollversammlung vorzustellen. Zudem sind gleichzeitig mehr Mitglieder der Fachschaft am Campus und insbesondere können sie so auf die Wahl und auf das Wahllokal aufmerksam gemacht werden. In der Regel wird das Wahllokal so gestaltet, dass es auf dem Weg zum Frühlingsfest nicht verfehlt werden kann. Insbesondere im Anblick der fallenden Wahlbeteiligung sollten wir dieses Modell fortführen, um möglichst viele Studierende zur Wahl zu animieren. In den vergangenen Jahren war die Terminfindung durch die rechtlichen und organisatorischen Anforderungen von Wahl und Frühlingsfest zusammen mit anderen Veranstaltungen des HPI schwierig. Mit dieser Änderung soll dem Fachschaftsrat mehr Spielraum zur Terminierung zur Verfügung stehen.

----

*Note that both the German motion and electoral code are legally binding and this is a service translation.*

# Motion
I move the student representative group to change the electoral code of the Digital Engineering student body as follows.

In § 3 (2) sentence 1, the phrase "at the latest, one month after beginning of the start of classes" is replaced by "at the latest, in the sixth week of the lecture period".

# Justification
Traditionally, the student representative group elections, the general meeting, and the spring party are held together. This gives candidates the opportunity to introduce themselves at the general meeting. Additionally, more members of the student body are on campus at the same time and, in particular, they can be made aware of the election and the polling station. As a rule, the polling station is designed in such a way that it cannot be missed on the way to the spring party. Especially in view of the falling voter turnout, we should continue this model in order to encourage as many students as possible to vote. In previous years, the legal and organizational requirements of the election and spring party together with other HPI events made it difficult to find a date. The proposed change gives the student representative group more leeway in scheduling.