### PR TITLE
Antrag an die Vollversammlung: SSE in den Studiengängen der Fachschaft nennen // Motion for the general meeting: Name SSE as part of the student body

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -5,7 +5,7 @@ Diese Satzung ist am 03.05.2021 durch Beschluss der Vollversammlung in Kraft get
 
 ## § 1 Geltungsbereich
 
-Alle Studierenden der Universität Potsdam in den Studiengängen IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity und Software Systems Engineering sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
+Alle Studierenden der Universität Potsdam in den Studienfächern IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity und Software Systems Engineering sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
 
 
 ## § 2 Organe

--- a/satzung.md
+++ b/satzung.md
@@ -5,7 +5,7 @@ Diese Satzung ist am 03.05.2021 durch Beschluss der Vollversammlung in Kraft get
 
 ## § 1 Geltungsbereich
 
-Alle Studierenden der Universität Potsdam in den Studiengängen IT-Systems Engineering, Data Engineering, Digital Health und Cybersecurity sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
+Alle Studierenden der Universität Potsdam in den Studiengängen IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity und Software Systems Engineering sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
 
 
 ## § 2 Organe

--- a/statutes.md
+++ b/statutes.md
@@ -7,7 +7,7 @@ These Statutes came into effect by resolution of all members at a General Meetin
 
 ## § 1 Scope
 
-Members of the Digital Engineering student body include all students of the University of Potsdam in the degree programs “IT Systems Engineering”, “Data Engineering”, “Digital Health”, and “Cybersecurity”, as well as PhD students enrolled at the Digital Engineering Faculty.
+Members of the Digital Engineering student body include all students of the University of Potsdam in the degree programs IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, and Software Systems Engineering, as well as PhD students enrolled at the Digital Engineering Faculty.
 
 
 ## § 2 Organization

--- a/statutes.md
+++ b/statutes.md
@@ -7,7 +7,7 @@ These Statutes came into effect by resolution of all members at a General Meetin
 
 ## § 1 Scope
 
-Members of the Digital Engineering student body include all students of the University of Potsdam in the degree programs IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, and Software Systems Engineering, as well as PhD students enrolled at the Digital Engineering Faculty.
+Members of the Digital Engineering student body include all students of the University of Potsdam in the subjects IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, and Software Systems Engineering, as well as PhD students enrolled at the Digital Engineering Faculty.
 
 
 ## § 2 Organization


### PR DESCRIPTION
[English version below]

# Antrag
I beantrage, die Vollversammlung der Fachschaft Digital Engineering möge die Satzung der Fachschaft Digital Engineering wie folgt ändern.

Der § 1 Geltungsbereich wird wie folgt neu gefasst: "Alle Studierenden der Universität Potsdam in den Studienfächern IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity und Software Systems Engineering sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering."

# Begründung
Das Studierendenparlament hat eine Neufassung der Satzung der Studierendenschaft beschlossen. Diese wird voraussichtlich in naher Zukunft in Kraft treten [1]. In diesem Rahmen ist vorgesehen, dass die Studienfächer, die eine Fachschaft bilden, in der jeweiligen Fachschaftssatzung angegeben sein sollen. 

Diese Änderung schlage ich im Auftrag des Fachschaftsrates vor, der allerdings formal kein Antragsrecht in der Vollversammlung besitzt.

[1] https://www.stupa.uni-potsdam.de/2023/08/veroeffentlichungen/satzung2023/

---
Note that both the German motion and statutes are legally binding and this is a service translation.

# Motion
I move the general meeting of the Digital Engineering student body to change the statutes of the Digital Engineering student body as follows.

Rewrite § 1 Scope as follows: "Members of the Digital Engineering student body include all students of the University of Potsdam in the subjects IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, and Software Systems Engineering, as well as PhD students enrolled at the Digital Engineering Faculty."

# Justification
The student parliament has adopted a new version of the university-wide student statutes. They are expected take effect in the near future [1]. In this context, it is planned that the study programs that form a student body should be specified in the respective student body statutes. 

I am proposing this change on behalf of the student representative group, which, however, does not formally have the right to submit motions to the general meeting.

[1] https://www.stupa.uni-potsdam.de/2023/08/veroeffentlichungen/satzung2023/
